### PR TITLE
bumped cairo to 2.5.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.4.4
+scarb 2.5.0
 starknet-foundry 0.16.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -55,8 +55,8 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin"
-version = "0.8.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.8.1#5c7a022f333dca721fe490c2191a811fa2566a89"
+version = "0.8.0"
+source = "git+https://github.com/ametel01/cairo-contracts.git?rev=a46a6b9#a46a6b9bfaf8b4c0fccbcbfd0c114ac5254968c1"
 
 [[package]]
 name = "snforge_std"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,8 +7,8 @@ test = "snforge test"
 
 [dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.16.0" }
-starknet = "2.4.4"
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.8.1" }
+starknet = "2.5.0"
+openzeppelin = { git = "https://github.com/ametel01/cairo-contracts.git", rev = "a46a6b9" }
 alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git" }
 alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git" }
 


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #49 
- [x] follows contribution [guide](../CONTRIBUTING.md)
- [x] code change includes tests
- [x] breaking change

<!-- PR description below -->
Upgraded starknet and scarb to version 2.5.0. Currently, the OpenZeppelin (OZ) repository hasn't been updated to these versions. As a temporary measure, i am using a fork of the OZ repository that is compatible with scarb 2.5.0.

Note on Warnings: Running snforge test generates several warnings related to other deps. These have been noted but not addressed in this update.