### PR TITLE
feat: binary hash digest

### DIFF
--- a/src/tree/binary/hasher.cairo
+++ b/src/tree/binary/hasher.cairo
@@ -1,18 +1,18 @@
+use alexandria_bytes::Bytes;
 use alexandria_bytes::BytesTrait;
 use blobstream_sn::tree::consts::{LEAF_PREFIX, NODE_PREFIX};
-use blobstream_sn::utils::encode_packed;
 
 fn nodeDigest(left: u256, right: u256) -> u256 {
-    let mut bytes = BytesTrait::new(1, array![NODE_PREFIX]);
+    let mut bytes = BytesTrait::new_empty();
+    bytes.append_u8(NODE_PREFIX);
     bytes.append_u256(left);
     bytes.append_u256(right);
     bytes.sha256()
 }
 
-fn leafDigest(data: u256) -> u256 {
-    let mut bytes = BytesTrait::new(1, array![LEAF_PREFIX]);
-    if data > 0 {
-        bytes.append_u256(data);
-    }
+fn leafDigest(data: @Bytes) -> u256 {
+    let mut bytes = BytesTrait::new_empty();
+    bytes.append_u8(LEAF_PREFIX);
+    bytes.concat(data);
     bytes.sha256()
 }

--- a/src/tree/binary/merkle_proof.cairo
+++ b/src/tree/binary/merkle_proof.cairo
@@ -7,4 +7,3 @@ struct BinaryMerkleProof {
     // number of leaves in the tree
     num_leaves: u256,
 }
-

--- a/src/tree/binary/tests/test_hasher.cairo
+++ b/src/tree/binary/tests/test_hasher.cairo
@@ -1,22 +1,24 @@
 use blobstream_sn::tree::binary::hasher::{leafDigest, nodeDigest};
+use alexandria_bytes::BytesTrait;
 
 #[test]
 fn leaf_digest_empty_test() {
     let exp: u256 = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d;
-    let digest = leafDigest(0);
+    let data = BytesTrait::new_empty();
+    let digest = leafDigest(@data);
     assert_eq!(digest, exp, "empty leaf digest");
 }
 
 #[test]
-#[ignore]
 fn leaf_digest_test() {
     let exp: u256 = 0x48c90c8ae24688d6bef5d48a30c2cc8b6754335a8db21793cc0a8e3bed321729;
-    let digest = leafDigest(0xdeadbeef);
+    let mut data = BytesTrait::new_empty();
+    data.append_u32(0xdeadbeef);
+    let digest = leafDigest(@data);
     assert_eq!(digest, exp, "leaf digest");
 }
 
 #[test]
-#[ignore]
 fn node_digest_empty_test() {
     let exp: u256 = 0xfe43d66afa4a9a5c4f9c9da89f4ffb52635c8f342e7ffb731d68e36c5982072a;
     let left: u256 = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d;
@@ -26,7 +28,6 @@ fn node_digest_empty_test() {
 }
 
 #[test]
-#[ignore]
 fn node_digest_children_test() {
     let exp: u256 = 0x62343bba7c4d6259f0d4863cdf476f1c0ac1b9fbe9244723a9b8b5c8aae72c38;
     let left: u256 = 0xdb55da3fc3098e9c42311c6013304ff36b19ef73d12ea932054b5ad51df4f49d;

--- a/src/tree/binary/tests/test_hasher.cairo
+++ b/src/tree/binary/tests/test_hasher.cairo
@@ -1,5 +1,5 @@
-use blobstream_sn::tree::binary::hasher::{leafDigest, nodeDigest};
 use alexandria_bytes::BytesTrait;
+use blobstream_sn::tree::binary::hasher::{leafDigest, nodeDigest};
 
 #[test]
 fn leaf_digest_empty_test() {

--- a/src/tree/binary/tests/test_hasher.cairo
+++ b/src/tree/binary/tests/test_hasher.cairo
@@ -24,7 +24,7 @@ fn node_digest_empty_test() {
     let left: u256 = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d;
     let right: u256 = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d;
     let digest = nodeDigest(left, right);
-    assert_eq!(digest, exp, "leaf digest");
+    assert_eq!(digest, exp, "empty node digest");
 }
 
 #[test]
@@ -33,5 +33,5 @@ fn node_digest_children_test() {
     let left: u256 = 0xdb55da3fc3098e9c42311c6013304ff36b19ef73d12ea932054b5ad51df4f49d;
     let right: u256 = 0xc75cb66ae28d8ebc6eded002c28a8ba0d06d3a78c6b5cbf9b2ade051f0775ac4;
     let digest = nodeDigest(left, right);
-    assert_eq!(digest, exp, "leaf digest");
+    assert_eq!(digest, exp, "node digest");
 }

--- a/src/tree/consts.cairo
+++ b/src/tree/consts.cairo
@@ -2,8 +2,8 @@ use blobstream_sn::tree::namespace::merkle_tree::Namespace;
 use core::bytes_31::bytes31_const;
 
 const MAX_HEIGHT: felt252 = 256;
-const LEAF_PREFIX: u128 = 0x00;
-const NODE_PREFIX: u128 = 0x01;
+const LEAF_PREFIX: u8 = 0x00;
+const NODE_PREFIX: u8 = 0x01;
 
 // utility function to provide the parity share namespace as a Namespace struct
 fn parity_share_namespace() -> Namespace {


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #23
- [x] follows contribution [guide](../CONTRIBUTING.md)
- [ ] code change includes tests
- [ ] breaking change

Implements Celestia's [Binary Tree Hasher](https://github.com/celestiaorg/blobstream-contracts/blob/master/src/lib/tree/binary/TreeHasher.sol). Also includes the [same tests](https://github.com/celestiaorg/blobstream-contracts/blob/master/src/lib/tree/binary/test/TreeHasher.t.sol) from Celestia's implementation.