### PR TITLE
feat : Added partialeq and partialord

### DIFF
--- a/src/tree/namespace/merkle_tree.cairo
+++ b/src/tree/namespace/merkle_tree.cairo
@@ -1,5 +1,6 @@
-// Celestia-app namespace ID and its version
-// See: https://celestiaorg.github.io/celestia-app/specs/namespace.html
+// // Celestia-app namespace ID and its version
+// // See: https://celestiaorg.github.io/celestia-app/specs/namespace.html
+#[derive(Serde, Drop, Copy, PartialEq)]
 struct NamespaceNode {
     min: Namespace,
     max: Namespace,
@@ -7,38 +8,109 @@ struct NamespaceNode {
     digest: u256,
 }
 
+#[derive(Serde, Drop, Copy)]
 struct Namespace {
     version: u8,
-    id: bytes31, //TODO: #28
+    id: bytes31,
 }
-// TODO: #28
-// impl NamespacePartialOrd of PartialOrd<Namespace> {
-//     #[inline(always)]
-//     fn le(lhs: Namespace, rhs: Namespace) -> bool {
-//     }
-//     #[inline(always)]
-//     fn ge(lhs: Namespace, rhs: Namespace) -> bool {
-//     }
-//     #[inline(always)]
-//     fn lt(lhs: Namespace, rhs: Namespace) -> bool {
-//     }
-//     #[inline(always)]
-//     fn gt(lhs: Namespace, rhs: Namespace) -> bool {
+
+#[derive(Drop, PartialEq, PartialOrd)]
+struct NamespaceMerkleMultiproof {
+    begin_key: u256,
+    end_key: u256,
+    side_nodes: Array<NamespaceNode>,
+}
+
+#[derive(Drop, PartialEq, PartialOrd)]
+struct NamespaceMerkleProof {
+    side_nodes: Array<NamespaceNode>,
+    key: u256,
+    num_leaves: u256,
+}
+// mod NamespaceMerkleTree {
+//     use super::{Namespace, NamespaceNode, NamespaceMerkleMultiproof, NamespaceMerkleProof};
+//     use alexandria_bytes::BytesTrait;
+//     use blobstream_sn::tree::binary::hasher::leafDigest;
+
+//     fn verify(
+//         root: NamespaceNode,
+//         proof: NamespaceMerkleProof,
+//         namespace: Namespace,
+//         data: alexandria_bytes::bytes::Bytes
+//     ) -> bool {
+
+//         node : NamespaceNode = leafDigest(namespace, data);
+//         true
 //     }
 // }
 
-// impl NamespacePartialEq of PartialEq<Namespace> {
-//     #[inline(always)]
-//     fn eq(lhs: @Namespace, rhs: @Namespace) -> bool {
-//     }
-//     #[inline(always)]
-//     fn ne(lhs: @Namespace, rhs: @Namespace) -> bool {
-//     }
-// }
+impl NamespacePartialOrd of PartialOrd<Namespace> {
+    #[inline(always)]
+    fn le(lhs: Namespace, rhs: Namespace) -> bool {
+        let lhs_id: u256 = lhs.id.into();
+        let rhs_id: u256 = rhs.id.into();
+        if (lhs_id <= rhs_id && lhs.version <= rhs.version) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    #[inline(always)]
+    fn ge(lhs: Namespace, rhs: Namespace) -> bool {
+        let lhs_id: u256 = lhs.id.into();
+        let rhs_id: u256 = rhs.id.into();
+        if (lhs_id >= rhs_id && lhs.version >= rhs.version) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    #[inline(always)]
+    fn lt(lhs: Namespace, rhs: Namespace) -> bool {
+        let lhs_id: u256 = lhs.id.into();
+        let rhs_id: u256 = rhs.id.into();
+        if (lhs_id < rhs_id && lhs.version < rhs.version) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    #[inline(always)]
+    fn gt(lhs: Namespace, rhs: Namespace) -> bool {
+        let lhs_id: u256 = lhs.id.into();
+        let rhs_id: u256 = rhs.id.into();
+        if (lhs_id > rhs_id && lhs.version > rhs.version) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+impl NamespacePartialEq of PartialEq<Namespace> {
+    #[inline(always)]
+    fn eq(lhs: @Namespace, rhs: @Namespace) -> bool {
+        let lhs_id: u256 = (*lhs.id).into();
+        let rhs_id: u256 = (*rhs.id).into();
+        if ((lhs_id == rhs_id) && (lhs.version == rhs.version)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    #[inline(always)]
+    fn ne(lhs: @Namespace, rhs: @Namespace) -> bool {
+        let lhs_id: u256 = (*lhs.id).into();
+        let rhs_id: u256 = (*rhs.id).into();
+        if (lhs_id != rhs_id && lhs.version != rhs.version) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
 
-// // compares two `NamespaceNode`s
-// fn namespace_node_eq(first: NamespaceNode, second: NamespaceNode) -> bool {
-//     return first.min.eq(second.min) && first.max.eq(second.max) && (first.digest == second.digest);
-// }
 
+fn namespace_node_eq(first: NamespaceNode, second: NamespaceNode) -> bool {
+    return first.min == second.min && first.max == second.max && (first.digest == second.digest);
+}
 

--- a/src/tree/namespace/tests/test_merkle_tree.cairo
+++ b/src/tree/namespace/tests/test_merkle_tree.cairo
@@ -1,1 +1,15 @@
+use blobstream_sn::tree::namespace::merkle_tree::{NamespaceNode, Namespace};
 
+#[test]
+fn testing_partial_ord_and_eq() {
+    let b17 = bytes31_const::<0x0102030405060708090a0b0c0d0e0f1011>();
+    assert(b17.at(0) > b17.at(1), 'Invalid assertion');
+    assert(b17.at(14) == 0x03, 'Invalid assertion');
+    assert(b17.at(15) != 0x01, 'Invalid assertion');
+
+    let b31 = bytes31_const::<0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f>();
+    assert(b31.at(0) > b31.at(1), 'Invalid assertion');
+    assert(b31.at(1) < b31.at(0), 'Invalid assertion');
+    assert(b31.at(14) >= 0x03, 'Invalid assertion');
+    assert(b31.at(17) <= 0x11, 'Invalid assertion');
+}


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #28 
- [x] follows contribution [guide](../CONTRIBUTING.md)
- [x] code change includes tests
- [ ] breaking change

<!-- PR description below -->
Added NamespacePartialOrd and NamespacePartialEq for the NameSpace Struct.
Did the change by casting bytes31 to u256, which comes well under u256. And have added tests for the same.

