### PR TITLE
feat: binary merkle tree

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!-- enter the gh issue after hash -->
 
 - [ ] issue #
-- [ ] follows contribution [guide](../CONTRIBUTING.md)
+- [ ] follows contribution [guide](https://github.com/keep-starknet-strange/blobstream-starknet/blob/main/CONTRIBUTING.md)
 - [ ] code change includes tests
 - [ ] breaking change
 

--- a/src/tree.cairo
+++ b/src/tree.cairo
@@ -1,10 +1,12 @@
 mod consts;
 mod binary {
     mod hasher;
+    mod merkle_tree;
     mod merkle_proof;
     #[cfg(test)]
     mod tests {
         mod test_hasher;
+        mod test_merkle_proof;
     }
 }
 mod namespace {

--- a/src/tree.cairo
+++ b/src/tree.cairo
@@ -1,8 +1,9 @@
 mod consts;
+mod utils;
 mod binary {
     mod hasher;
-    mod merkle_tree;
     mod merkle_proof;
+    mod merkle_tree;
     #[cfg(test)]
     mod tests {
         mod test_hasher;
@@ -20,4 +21,5 @@ mod namespace {
 #[cfg(test)]
 mod tests {
     mod test_consts;
+    mod test_utils;
 }

--- a/src/tree/binary/hasher.cairo
+++ b/src/tree/binary/hasher.cairo
@@ -2,7 +2,7 @@ use alexandria_bytes::Bytes;
 use alexandria_bytes::BytesTrait;
 use blobstream_sn::tree::consts::{LEAF_PREFIX, NODE_PREFIX};
 
-fn nodeDigest(left: u256, right: u256) -> u256 {
+fn node_digest(left: u256, right: u256) -> u256 {
     let mut bytes = BytesTrait::new_empty();
     bytes.append_u8(NODE_PREFIX);
     bytes.append_u256(left);
@@ -10,7 +10,7 @@ fn nodeDigest(left: u256, right: u256) -> u256 {
     bytes.sha256()
 }
 
-fn leafDigest(data: @Bytes) -> u256 {
+fn leaf_digest(data: @Bytes) -> u256 {
     let mut bytes = BytesTrait::new_empty();
     bytes.append_u8(LEAF_PREFIX);
     bytes.concat(data);

--- a/src/tree/binary/merkle_tree.cairo
+++ b/src/tree/binary/merkle_tree.cairo
@@ -1,9 +1,10 @@
 use alexandria_bytes::Bytes;
+use blobstream_sn::tree::binary::hasher::{leaf_digest, node_digest};
 use blobstream_sn::tree::binary::merkle_proof::BinaryMerkleProof;
+use blobstream_sn::tree::utils::{path_length_from_key, get_split_point};
 
-#[derive(Drop)]
+#[derive(Copy, Drop)]
 enum ErrorCodes {
-    // TODO: Comment these
     NoError,
     InvalidNumberOfSideNodes,
     KeyNotInTree,
@@ -12,16 +13,146 @@ enum ErrorCodes {
     ExpectedAtLeastOneInnerHash,
 }
 
-// TODO: allow for custom type instead of u256?
+fn is_no_error(error: ErrorCodes) -> bool {
+    //match error {
+    //    ErrorCodes::NoError => true,
+    //    _ => false,
+    //}
+    match error {
+        ErrorCodes::NoError => true,
+        ErrorCodes::InvalidNumberOfSideNodes => false,
+        ErrorCodes::KeyNotInTree => false,
+        ErrorCodes::InvalidNumberOfLeavesInProof => false,
+        ErrorCodes::UnexpectedInnerHashes => false,
+        ErrorCodes::ExpectedAtLeastOneInnerHash => false,
+    }
+}
+
 fn verify(root: u256, proof: @BinaryMerkleProof, data: @Bytes) -> (bool, ErrorCodes) {
-    return (false, ErrorCodes::NoError);
+    if (*proof.num_leaves <= 1) {
+        if (proof.side_nodes.len() != 0) {
+            return (false, ErrorCodes::InvalidNumberOfSideNodes);
+        }
+    } else if (proof
+        .side_nodes
+        .len()
+        .into() != path_length_from_key(*proof.key, *proof.num_leaves)) {
+        return (false, ErrorCodes::InvalidNumberOfSideNodes);
+    }
+
+    if (*proof.key >= *proof.num_leaves) {
+        return (false, ErrorCodes::KeyNotInTree);
+    }
+
+    let digest: u256 = leaf_digest(data);
+
+    if (proof.side_nodes.len() == 0) {
+        if (*proof.num_leaves == 1) {
+            return (root == digest, ErrorCodes::NoError);
+        } else {
+            return (false, ErrorCodes::NoError);
+        }
+    }
+
+    let (computed_hash, error) = compute_root_hash(
+        *proof.key, *proof.num_leaves, digest, proof.side_nodes.span()
+    );
+
+    //match error {
+    //    ErrorCodes::NoError => (),
+    //    _ => { return (false, error); }
+    //}
+    match error {
+        ErrorCodes::NoError => (),
+        ErrorCodes::InvalidNumberOfSideNodes => { return (false, error); },
+        ErrorCodes::KeyNotInTree => { return (false, error); },
+        ErrorCodes::InvalidNumberOfLeavesInProof => { return (false, error); },
+        ErrorCodes::UnexpectedInnerHashes => { return (false, error); },
+        ErrorCodes::ExpectedAtLeastOneInnerHash => { return (false, error); },
+    }
+
+    return (computed_hash == root, ErrorCodes::NoError);
 }
 
-fn compute_root_hash(key: u256, num_leaves: u256, leaf_hash: u256,
-                     side_nodes: @Array<u256>) -> (u256, ErrorCodes) {
-    return (0, ErrorCodes::NoError);
+fn compute_root_hash(
+    key: u256, num_leaves: u256, leaf_hash: u256, side_nodes: Span<u256>
+) -> (u256, ErrorCodes) {
+    if (num_leaves == 0) {
+        return (leaf_hash, ErrorCodes::InvalidNumberOfLeavesInProof);
+    }
+    if (num_leaves == 1) {
+        if (side_nodes.len() != 0) {
+            return (leaf_hash, ErrorCodes::UnexpectedInnerHashes);
+        }
+        return (leaf_hash, ErrorCodes::NoError);
+    }
+    if (side_nodes.len() == 0) {
+        return (leaf_hash, ErrorCodes::ExpectedAtLeastOneInnerHash);
+    }
+
+    let num_left: u256 = get_split_point(num_leaves);
+    let side_nodes_left: Array<u256> = slice(side_nodes, 0, side_nodes.len().into() - 1);
+    if (key < num_left) {
+        let (left_hash, error) = compute_root_hash(
+            key, num_left, leaf_hash, side_nodes_left.span()
+        );
+        //match error {
+        //    ErrorCodes::NoError => (),
+        //    _ => { return (leaf_hash, error); }
+        //}
+        match error {
+            ErrorCodes::NoError => (),
+            ErrorCodes::InvalidNumberOfSideNodes => { return (leaf_hash, error); },
+            ErrorCodes::KeyNotInTree => { return (leaf_hash, error); },
+            ErrorCodes::InvalidNumberOfLeavesInProof => { return (leaf_hash, error); },
+            ErrorCodes::UnexpectedInnerHashes => { return (leaf_hash, error); },
+            ErrorCodes::ExpectedAtLeastOneInnerHash => { return (leaf_hash, error); },
+        }
+        return (node_digest(left_hash, *side_nodes.at(side_nodes.len() - 1)), ErrorCodes::NoError);
+    }
+
+    let (right_hash, error) = compute_root_hash(
+        key - num_left, num_leaves - num_left, leaf_hash, side_nodes_left.span()
+    );
+    //match error {
+    //    ErrorCodes::NoError => (),
+    //    _ => { return (leaf_hash, error); }
+    //}
+    match error {
+        ErrorCodes::NoError => (),
+        ErrorCodes::InvalidNumberOfSideNodes => { return (leaf_hash, error); },
+        ErrorCodes::KeyNotInTree => { return (leaf_hash, error); },
+        ErrorCodes::InvalidNumberOfLeavesInProof => { return (leaf_hash, error); },
+        ErrorCodes::UnexpectedInnerHashes => { return (leaf_hash, error); },
+        ErrorCodes::ExpectedAtLeastOneInnerHash => { return (leaf_hash, error); },
+    }
+    return (node_digest(*side_nodes.at(side_nodes.len() - 1), right_hash), ErrorCodes::NoError);
 }
 
-fn slice(data: @Array<u256>, begin: u256, end: u256) -> @Array<u256> {
-    return @array![];
+fn slice(mut data: Span<u256>, begin: u256, end: u256) -> Array<u256> {
+    if (begin > end) {
+        panic!("slice: begin > end");
+    }
+    if (begin > data.len().into() || end > data.len().into()) {
+        panic!("slice: begin or end out of bounds");
+    }
+
+    let mut out: Array<u256> = array![];
+    let mut i: u256 = 0;
+    loop {
+        if (i == begin) {
+            break;
+        }
+        data.pop_front().unwrap();
+        i += 1;
+    };
+    loop {
+        if (i == end) {
+            break;
+        }
+        out.append(*data.pop_front().unwrap());
+        i += 1;
+    };
+
+    return out;
 }

--- a/src/tree/binary/merkle_tree.cairo
+++ b/src/tree/binary/merkle_tree.cairo
@@ -1,0 +1,27 @@
+use alexandria_bytes::Bytes;
+use blobstream_sn::tree::binary::merkle_proof::BinaryMerkleProof;
+
+#[derive(Drop)]
+enum ErrorCodes {
+    // TODO: Comment these
+    NoError,
+    InvalidNumberOfSideNodes,
+    KeyNotInTree,
+    InvalidNumberOfLeavesInProof,
+    UnexpectedInnerHashes,
+    ExpectedAtLeastOneInnerHash,
+}
+
+// TODO: allow for custom type instead of u256?
+fn verify(root: u256, proof: @BinaryMerkleProof, data: @Bytes) -> (bool, ErrorCodes) {
+    return (false, ErrorCodes::NoError);
+}
+
+fn compute_root_hash(key: u256, num_leaves: u256, leaf_hash: u256,
+                     side_nodes: @Array<u256>) -> (u256, ErrorCodes) {
+    return (0, ErrorCodes::NoError);
+}
+
+fn slice(data: @Array<u256>, begin: u256, end: u256) -> @Array<u256> {
+    return @array![];
+}

--- a/src/tree/binary/tests/test_hasher.cairo
+++ b/src/tree/binary/tests/test_hasher.cairo
@@ -1,11 +1,11 @@
 use alexandria_bytes::BytesTrait;
-use blobstream_sn::tree::binary::hasher::{leafDigest, nodeDigest};
+use blobstream_sn::tree::binary::hasher::{leaf_digest, node_digest};
 
 #[test]
 fn leaf_digest_empty_test() {
     let exp: u256 = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d;
     let data = BytesTrait::new_empty();
-    let digest = leafDigest(@data);
+    let digest = leaf_digest(@data);
     assert_eq!(digest, exp, "empty leaf digest");
 }
 
@@ -14,7 +14,7 @@ fn leaf_digest_test() {
     let exp: u256 = 0x48c90c8ae24688d6bef5d48a30c2cc8b6754335a8db21793cc0a8e3bed321729;
     let mut data = BytesTrait::new_empty();
     data.append_u32(0xdeadbeef);
-    let digest = leafDigest(@data);
+    let digest = leaf_digest(@data);
     assert_eq!(digest, exp, "leaf digest");
 }
 
@@ -23,7 +23,7 @@ fn node_digest_empty_test() {
     let exp: u256 = 0xfe43d66afa4a9a5c4f9c9da89f4ffb52635c8f342e7ffb731d68e36c5982072a;
     let left: u256 = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d;
     let right: u256 = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d;
-    let digest = nodeDigest(left, right);
+    let digest = node_digest(left, right);
     assert_eq!(digest, exp, "empty node digest");
 }
 
@@ -32,6 +32,6 @@ fn node_digest_children_test() {
     let exp: u256 = 0x62343bba7c4d6259f0d4863cdf476f1c0ac1b9fbe9244723a9b8b5c8aae72c38;
     let left: u256 = 0xdb55da3fc3098e9c42311c6013304ff36b19ef73d12ea932054b5ad51df4f49d;
     let right: u256 = 0xc75cb66ae28d8ebc6eded002c28a8ba0d06d3a78c6b5cbf9b2ade051f0775ac4;
-    let digest = nodeDigest(left, right);
+    let digest = node_digest(left, right);
     assert_eq!(digest, exp, "node digest");
 }

--- a/src/tree/binary/tests/test_merkle_proof.cairo
+++ b/src/tree/binary/tests/test_merkle_proof.cairo
@@ -1,0 +1,129 @@
+use alexandria_bytes::BytesTrait;
+use blobstream_sn::tree::binary::merkle_proof::BinaryMerkleProof;
+use blobstream_sn::tree::binary::merkle_tree;
+
+#[test]
+fn verify_none_test() {
+    let root: u256 = BytesTrait::new_empty().sha256();
+    let side_nodes: Array<u256> = array![];
+    let key: u256 = 0;
+    let num_leaves: u256 = 0;
+    let proof: BinaryMerkleProof = BinaryMerkleProof{ side_nodes, key, num_leaves };
+    let data = BytesTrait::new_empty();
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert_eq!(is_valid, false);
+}
+
+#[test]
+#[ignore]
+fn verify_one_leaf_empty_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_one_leaf_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_one_leaf_01_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_leaf_one_of_eight_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_leaf_two_of_eight_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_leaf_three_of_eight_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_leaf_seven_of_eight_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_leaf_eight_of_eight_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_proof_of_five_leaves_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_invalid_proof_root_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_invalid_proof_key_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_invalid_proof_number_of_leaves_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_invalid_proof_side_nodes_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn verify_invalid_proof_data_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn valid_slice_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn same_key_and_leaves_number_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn consecutive_key_and_number_of_leaves_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn invalid_slice_begin_end_test() {
+    assert_eq!(false, true);
+}
+
+#[test]
+#[ignore]
+fn out_of_bounds_slice_test() {
+    assert_eq!(false, true);
+}

--- a/src/tree/binary/tests/test_merkle_proof.cairo
+++ b/src/tree/binary/tests/test_merkle_proof.cairo
@@ -1,5 +1,6 @@
 use alexandria_bytes::BytesTrait;
 use blobstream_sn::tree::binary::merkle_proof::BinaryMerkleProof;
+use blobstream_sn::tree::binary::merkle_tree::ErrorCodes;
 use blobstream_sn::tree::binary::merkle_tree;
 
 #[test]
@@ -23,7 +24,7 @@ fn verify_one_leaf_empty_test() {
     let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
     let data = BytesTrait::new_empty();
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(merkle_tree::is_no_error(error_code), "verify one leaf empty test failed with error");
+    assert!(error_code == ErrorCodes::NoError, "verify one leaf empty test failed with error");
     assert!(is_valid, "verify one leaf empty test invalid");
 }
 
@@ -37,7 +38,7 @@ fn verify_one_leaf_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u32(0xdeadbeef);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(merkle_tree::is_no_error(error_code), "verify one leaf test failed with error");
+    assert!(error_code == ErrorCodes::NoError, "verify one leaf test failed with error");
     assert!(is_valid, "verify one leaf test invalid");
 }
 
@@ -51,7 +52,7 @@ fn verify_one_leaf_01_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(merkle_tree::is_no_error(error_code), "verify one leaf 01 test failed with error");
+    assert!(error_code == ErrorCodes::NoError, "verify one leaf 01 test failed with error");
     assert!(is_valid, "verify one leaf 01 test invalid");
 }
 
@@ -69,9 +70,7 @@ fn verify_leaf_one_of_eight_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(
-        merkle_tree::is_no_error(error_code), "verify leaf one of eight test failed with error"
-    );
+    assert!(error_code == ErrorCodes::NoError, "verify leaf one of eight test failed with error");
     assert!(is_valid, "verify leaf one of eight test invalid");
 }
 
@@ -89,9 +88,7 @@ fn verify_leaf_two_of_eight_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x02);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(
-        merkle_tree::is_no_error(error_code), "verify leaf two of eight test failed with error"
-    );
+    assert!(error_code == ErrorCodes::NoError, "verify leaf two of eight test failed with error");
     assert!(is_valid, "verify leaf two of eight test invalid");
 }
 
@@ -109,9 +106,7 @@ fn verify_leaf_three_of_eight_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x03);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(
-        merkle_tree::is_no_error(error_code), "verify leaf three of eight test failed with error"
-    );
+    assert!(error_code == ErrorCodes::NoError, "verify leaf three of eight test failed with error");
     assert!(is_valid, "verify leaf three of eight test invalid");
 }
 
@@ -129,9 +124,7 @@ fn verify_leaf_seven_of_eight_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x07);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(
-        merkle_tree::is_no_error(error_code), "verify leaf seven of eight test failed with error"
-    );
+    assert!(error_code == ErrorCodes::NoError, "verify leaf seven of eight test failed with error");
     assert!(is_valid, "verify leaf seven of eight test invalid");
 }
 
@@ -149,9 +142,7 @@ fn verify_leaf_eight_of_eight_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x08);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(
-        merkle_tree::is_no_error(error_code), "verify leaf eight of eight test failed with error"
-    );
+    assert!(error_code == ErrorCodes::NoError, "verify leaf eight of eight test failed with error");
     assert!(is_valid, "verify leaf eight of eight test invalid");
 }
 
@@ -171,7 +162,7 @@ fn verify_proof_of_five_leaves_test() {
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
     assert!(
-        merkle_tree::is_no_error(error_code), "verify proof of five leaves test failed with error"
+        error_code == ErrorCodes::NoError, "verify proof of five leaves test failed with error"
     );
     assert!(is_valid, "verify proof of five leaves test invalid");
 }
@@ -192,9 +183,7 @@ fn verify_invalid_proof_root_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(
-        merkle_tree::is_no_error(error_code), "verify invalid proof root test failed with error"
-    );
+    assert!(error_code == ErrorCodes::NoError, "verify invalid proof root test failed with error");
     assert_eq!(is_valid, false, "verify invalid proof root test should be invalid");
 }
 
@@ -214,9 +203,7 @@ fn verify_invalid_proof_key_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(
-        merkle_tree::is_no_error(error_code), "verify invalid proof key test failed with error"
-    );
+    assert!(error_code == ErrorCodes::NoError, "verify invalid proof key test failed with error");
     assert_eq!(is_valid, false, "verify invalid proof key test should be invalid");
 }
 
@@ -236,6 +223,10 @@ fn verify_invalid_proof_number_of_leaves_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        error_code == ErrorCodes::InvalidNumberOfSideNodes,
+        "verify invalid proof number of leaves test failed with error"
+    );
     assert_eq!(is_valid, false, "verify invalid proof number of leaves test should be invalid");
 }
 
@@ -256,8 +247,7 @@ fn verify_invalid_proof_side_nodes_test() {
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
     assert!(
-        merkle_tree::is_no_error(error_code),
-        "verify invalid proof side nodes test failed with error"
+        error_code == ErrorCodes::NoError, "verify invalid proof side nodes test failed with error"
     );
     assert_eq!(is_valid, false, "verify invalid proof side nodes test should be invalid");
 }
@@ -278,18 +268,8 @@ fn verify_invalid_proof_data_test() {
     // correct data.append_u8(0x01);
     data.append_u32(0x012345);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert!(
-        merkle_tree::is_no_error(error_code), "verify invalid proof data test failed with error"
-    );
+    assert!(error_code == ErrorCodes::NoError, "verify invalid proof data test failed with error");
     assert_eq!(is_valid, false, "verify invalid proof data test should be invalid");
-}
-
-#[test]
-fn valid_slice_test() {
-    let data: Array<u256> = array!['a', 'b', 'c', 'd'];
-    let result: Array<u256> = merkle_tree::slice(data.span(), 1, 3);
-    assert_eq!(result.at(0), data.at(1), "valid slice test failed with first element");
-    assert_eq!(result.at(1), data.at(2), "valid slice test failed with second element");
 }
 
 #[test]
@@ -302,6 +282,10 @@ fn same_key_and_leaves_number_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        error_code == ErrorCodes::InvalidNumberOfSideNodes,
+        "same key and leaves number test failed with error"
+    );
     assert_eq!(is_valid, false, "same key and leaves number test failed");
 }
 
@@ -315,19 +299,27 @@ fn consecutive_key_and_number_of_leaves_test() {
     let mut data = BytesTrait::new_empty();
     data.append_u8(0x01);
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        error_code == ErrorCodes::InvalidNumberOfSideNodes,
+        "consecutive key and number of leaves test failed with error"
+    );
     assert_eq!(is_valid, false, "consecutive key and number of leaves test failed");
 }
 
 #[test]
-#[should_panic(expected: ("slice: begin > end",))]
-fn invalid_slice_begin_end_test() {
-    let data: Array<u256> = array!['a', 'b', 'c', 'd'];
-    let result: Array<u256> = merkle_tree::slice(data.span(), 2, 1);
-}
-
-#[test]
-#[should_panic(expected: ("slice: begin or end out of bounds",))]
-fn out_of_bounds_slice_test() {
-    let data: Array<u256> = array!['a', 'b', 'c', 'd'];
-    let result: Array<u256> = merkle_tree::slice(data.span(), 2, 5);
+fn key_not_in_tree_test() {
+    let root: u256 = 0xc1ad6548cb4c7663110df219ec8b36ca63b01158956f4be31a38a88d0c7f7071;
+    let side_nodes: Array<u256> = array![
+        0xfcf0a6c700dd13e274b6fba8deea8dd9b26e4eedde3495717cac8408c9c5177f,
+        0x78850a5ab36238b076dd99fd258c70d523168704247988a94caa8c9ccd056b8d,
+        0x4301a067262bbb18b4919742326f6f6d706099f9c0e8b0f2db7b88f204b2cf09
+    ];
+    let key: u256 = 9;
+    let num_leaves: u256 = 8;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(error_code == ErrorCodes::KeyNotInTree, "key not in tree test failed with error");
+    assert_eq!(is_valid, false, "key not in tree test failed");
 }

--- a/src/tree/binary/tests/test_merkle_proof.cairo
+++ b/src/tree/binary/tests/test_merkle_proof.cairo
@@ -8,122 +8,326 @@ fn verify_none_test() {
     let side_nodes: Array<u256> = array![];
     let key: u256 = 0;
     let num_leaves: u256 = 0;
-    let proof: BinaryMerkleProof = BinaryMerkleProof{ side_nodes, key, num_leaves };
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
     let data = BytesTrait::new_empty();
     let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
-    assert_eq!(is_valid, false);
+    assert_eq!(is_valid, false, "verify none test failed");
 }
 
 #[test]
-#[ignore]
 fn verify_one_leaf_empty_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0x6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d;
+    let side_nodes: Array<u256> = array![];
+    let key: u256 = 0;
+    let num_leaves: u256 = 1;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let data = BytesTrait::new_empty();
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(merkle_tree::is_no_error(error_code), "verify one leaf empty test failed with error");
+    assert!(is_valid, "verify one leaf empty test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_one_leaf_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0x48c90c8ae24688d6bef5d48a30c2cc8b6754335a8db21793cc0a8e3bed321729;
+    let side_nodes: Array<u256> = array![];
+    let key: u256 = 0;
+    let num_leaves: u256 = 1;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u32(0xdeadbeef);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(merkle_tree::is_no_error(error_code), "verify one leaf test failed with error");
+    assert!(is_valid, "verify one leaf test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_one_leaf_01_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xb413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2;
+    let side_nodes: Array<u256> = array![];
+    let key: u256 = 0;
+    let num_leaves: u256 = 1;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(merkle_tree::is_no_error(error_code), "verify one leaf 01 test failed with error");
+    assert!(is_valid, "verify one leaf 01 test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_leaf_one_of_eight_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xc1ad6548cb4c7663110df219ec8b36ca63b01158956f4be31a38a88d0c7f7071;
+    let side_nodes: Array<u256> = array![
+        0xfcf0a6c700dd13e274b6fba8deea8dd9b26e4eedde3495717cac8408c9c5177f,
+        0x78850a5ab36238b076dd99fd258c70d523168704247988a94caa8c9ccd056b8d,
+        0x4301a067262bbb18b4919742326f6f6d706099f9c0e8b0f2db7b88f204b2cf09
+    ];
+    let key: u256 = 0;
+    let num_leaves: u256 = 8;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify leaf one of eight test failed with error"
+    );
+    assert!(is_valid, "verify leaf one of eight test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_leaf_two_of_eight_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xc1ad6548cb4c7663110df219ec8b36ca63b01158956f4be31a38a88d0c7f7071;
+    let side_nodes: Array<u256> = array![
+        0xb413f47d13ee2fe6c845b2ee141af81de858df4ec549a58b7970bb96645bc8d2,
+        0x78850a5ab36238b076dd99fd258c70d523168704247988a94caa8c9ccd056b8d,
+        0x4301a067262bbb18b4919742326f6f6d706099f9c0e8b0f2db7b88f204b2cf09
+    ];
+    let key: u256 = 1;
+    let num_leaves: u256 = 8;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x02);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify leaf two of eight test failed with error"
+    );
+    assert!(is_valid, "verify leaf two of eight test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_leaf_three_of_eight_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xc1ad6548cb4c7663110df219ec8b36ca63b01158956f4be31a38a88d0c7f7071;
+    let side_nodes: Array<u256> = array![
+        0x4f35212d12f9ad2036492c95f1fe79baf4ec7bd9bef3dffa7579f2293ff546a4,
+        0x6bcf0e2e93e0a18e22789aee965e6553f4fbe93f0acfc4a705d691c8311c4965,
+        0x4301a067262bbb18b4919742326f6f6d706099f9c0e8b0f2db7b88f204b2cf09
+    ];
+    let key: u256 = 2;
+    let num_leaves: u256 = 8;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x03);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify leaf three of eight test failed with error"
+    );
+    assert!(is_valid, "verify leaf three of eight test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_leaf_seven_of_eight_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xc1ad6548cb4c7663110df219ec8b36ca63b01158956f4be31a38a88d0c7f7071;
+    let side_nodes: Array<u256> = array![
+        0xb4c43b50bf245bd727623e3c775a8fcfb8d823d00b57dd65f7f79dd33f126315,
+        0x90eeb2c4a04ec33ee4dd2677593331910e4203db4fcc120a6cdb95b13cfe83f0,
+        0xfa02d31a63cc11cc624881e52af14af7a1c6ab745efa71021cb24086b9b1793f
+    ];
+    let key: u256 = 6;
+    let num_leaves: u256 = 8;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x07);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify leaf seven of eight test failed with error"
+    );
+    assert!(is_valid, "verify leaf seven of eight test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_leaf_eight_of_eight_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xc1ad6548cb4c7663110df219ec8b36ca63b01158956f4be31a38a88d0c7f7071;
+    let side_nodes: Array<u256> = array![
+        0x2ecd8a6b7d2845546659ad4cf443533cf921b19dc81fa83934e83821b4dfdcb7,
+        0x90eeb2c4a04ec33ee4dd2677593331910e4203db4fcc120a6cdb95b13cfe83f0,
+        0xfa02d31a63cc11cc624881e52af14af7a1c6ab745efa71021cb24086b9b1793f
+    ];
+    let key: u256 = 7;
+    let num_leaves: u256 = 8;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x08);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify leaf eight of eight test failed with error"
+    );
+    assert!(is_valid, "verify leaf eight of eight test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_proof_of_five_leaves_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xb855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let side_nodes: Array<u256> = array![
+        0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7,
+        0x52c56b473e5246933e7852989cd9feba3b38f078742b93afff1e65ed46797825,
+        0x4f35212d12f9ad2036492c95f1fe79baf4ec7bd9bef3dffa7579f2293ff546a4
+    ];
+
+    let key: u256 = 1;
+    let num_leaves: u256 = 5;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify proof of five leaves test failed with error"
+    );
+    assert!(is_valid, "verify proof of five leaves test invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_invalid_proof_root_test() {
-    assert_eq!(false, true);
+    // correct root: u256 = 0xb855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let root: u256 = 0xc855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let side_nodes: Array<u256> = array![
+        0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7,
+        0x52c56b473e5246933e7852989cd9feba3b38f078742b93afff1e65ed46797825,
+        0x4f35212d12f9ad2036492c95f1fe79baf4ec7bd9bef3dffa7579f2293ff546a4
+    ];
+
+    let key: u256 = 1;
+    let num_leaves: u256 = 5;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify invalid proof root test failed with error"
+    );
+    assert_eq!(is_valid, false, "verify invalid proof root test should be invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_invalid_proof_key_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xb855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let side_nodes: Array<u256> = array![
+        0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7,
+        0x52c56b473e5246933e7852989cd9feba3b38f078742b93afff1e65ed46797825,
+        0x4f35212d12f9ad2036492c95f1fe79baf4ec7bd9bef3dffa7579f2293ff546a4
+    ];
+
+    // correct key: u256 = 1;
+    let key: u256 = 2;
+    let num_leaves: u256 = 5;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify invalid proof key test failed with error"
+    );
+    assert_eq!(is_valid, false, "verify invalid proof key test should be invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_invalid_proof_number_of_leaves_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xb855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let side_nodes: Array<u256> = array![
+        0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7,
+        0x52c56b473e5246933e7852989cd9feba3b38f078742b93afff1e65ed46797825,
+        0x4f35212d12f9ad2036492c95f1fe79baf4ec7bd9bef3dffa7579f2293ff546a4
+    ];
+
+    let key: u256 = 1;
+    // correct num_leaves: u256 = 5;
+    let num_leaves: u256 = 200;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert_eq!(is_valid, false, "verify invalid proof number of leaves test should be invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_invalid_proof_side_nodes_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xb855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let side_nodes: Array<u256> = array![
+        0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7,
+        0x52c56b473e5246933e7852989cd9feba3b38f078742b93afff1e65ed46797825,
+        // correct 0x4f35212d12f9ad2036492c95f1fe79baf4ec7bd9bef3dffa7579f2293ff546a4
+        0x5f35212d12f9ad2036492c95f1fe79baf4ec7bd9bef3dffa7579f2293ff546a4
+    ];
+
+    let key: u256 = 1;
+    let num_leaves: u256 = 5;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code),
+        "verify invalid proof side nodes test failed with error"
+    );
+    assert_eq!(is_valid, false, "verify invalid proof side nodes test should be invalid");
 }
 
 #[test]
-#[ignore]
 fn verify_invalid_proof_data_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xb855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let side_nodes: Array<u256> = array![
+        0x96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7,
+        0x52c56b473e5246933e7852989cd9feba3b38f078742b93afff1e65ed46797825,
+        0x4f35212d12f9ad2036492c95f1fe79baf4ec7bd9bef3dffa7579f2293ff546a4
+    ];
+
+    let key: u256 = 1;
+    let num_leaves: u256 = 5;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    // correct data.append_u8(0x01);
+    data.append_u32(0x012345);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert!(
+        merkle_tree::is_no_error(error_code), "verify invalid proof data test failed with error"
+    );
+    assert_eq!(is_valid, false, "verify invalid proof data test should be invalid");
 }
 
 #[test]
-#[ignore]
 fn valid_slice_test() {
-    assert_eq!(false, true);
+    let data: Array<u256> = array!['a', 'b', 'c', 'd'];
+    let result: Array<u256> = merkle_tree::slice(data.span(), 1, 3);
+    assert_eq!(result.at(0), data.at(1), "valid slice test failed with first element");
+    assert_eq!(result.at(1), data.at(2), "valid slice test failed with second element");
 }
 
 #[test]
-#[ignore]
 fn same_key_and_leaves_number_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xb855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let side_nodes: Array<u256> = array![];
+    let key: u256 = 3;
+    let num_leaves: u256 = 3;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert_eq!(is_valid, false, "same key and leaves number test failed");
 }
 
 #[test]
-#[ignore]
 fn consecutive_key_and_number_of_leaves_test() {
-    assert_eq!(false, true);
+    let root: u256 = 0xb855b42d6c30f5b087e05266783fbd6e394f7b926013ccaa67700a8b0c5a596f;
+    let side_nodes: Array<u256> = array![];
+    let key: u256 = 6;
+    let num_leaves: u256 = 7;
+    let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
+    let mut data = BytesTrait::new_empty();
+    data.append_u8(0x01);
+    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    assert_eq!(is_valid, false, "consecutive key and number of leaves test failed");
 }
 
 #[test]
-#[ignore]
+#[should_panic(expected: ("slice: begin > end",))]
 fn invalid_slice_begin_end_test() {
-    assert_eq!(false, true);
+    let data: Array<u256> = array!['a', 'b', 'c', 'd'];
+    let result: Array<u256> = merkle_tree::slice(data.span(), 2, 1);
 }
 
 #[test]
-#[ignore]
+#[should_panic(expected: ("slice: begin or end out of bounds",))]
 fn out_of_bounds_slice_test() {
-    assert_eq!(false, true);
+    let data: Array<u256> = array!['a', 'b', 'c', 'd'];
+    let result: Array<u256> = merkle_tree::slice(data.span(), 2, 5);
 }

--- a/src/tree/consts.cairo
+++ b/src/tree/consts.cairo
@@ -1,7 +1,7 @@
 use blobstream_sn::tree::namespace::merkle_tree::Namespace;
 use core::bytes_31::bytes31_const;
 
-const MAX_HEIGHT: felt252 = 256;
+const MAX_HEIGHT: u256 = 256;
 const LEAF_PREFIX: u8 = 0x00;
 const NODE_PREFIX: u8 = 0x01;
 

--- a/src/tree/tests/test_utils.cairo
+++ b/src/tree/tests/test_utils.cairo
@@ -1,15 +1,52 @@
-use blobstream_sn::tree::utils::path_length_from_key;
+use blobstream_sn::tree::utils;
+
+#[test]
+fn test_get_starting_bit() {
+    assert_eq!(utils::get_starting_bit(0), 0, "starting bit 0 test failed");
+    assert_eq!(utils::get_starting_bit(1), 0, "starting bit 1 test failed");
+    assert_eq!(utils::get_starting_bit(2), 1, "starting bit 2 test failed");
+    assert_eq!(utils::get_starting_bit(4), 2, "starting bit 4 test failed");
+    assert_eq!(utils::get_starting_bit(6), 3, "starting bit 6 test failed");
+    assert_eq!(utils::get_starting_bit(8), 3, "starting bit 8 test failed");
+}
 
 #[test]
 fn test_path_length_from_keys() {
-    assert_eq!(path_length_from_key(0, 2), 1, "key (0, 2) test failed");
-    assert_eq!(path_length_from_key(1, 2), 1, "key (1, 2) test failed");
-    assert_eq!(path_length_from_key(0, 8), 3, "key (0, 8) test failed");
-    assert_eq!(path_length_from_key(1, 8), 3, "key (1, 8) test failed");
-    assert_eq!(path_length_from_key(2, 8), 3, "key (2, 8) test failed");
-    assert_eq!(path_length_from_key(3, 8), 3, "key (3, 8) test failed");
-    assert_eq!(path_length_from_key(4, 8), 3, "key (4, 8) test failed");
-    assert_eq!(path_length_from_key(5, 8), 3, "key (5, 8) test failed");
-    assert_eq!(path_length_from_key(6, 8), 3, "key (6, 8) test failed");
-    assert_eq!(path_length_from_key(7, 8), 3, "key (7, 8) test failed");
+    assert_eq!(utils::path_length_from_key(0, 2), 1, "key (0, 2) test failed");
+    assert_eq!(utils::path_length_from_key(1, 2), 1, "key (1, 2) test failed");
+    assert_eq!(utils::path_length_from_key(0, 8), 3, "key (0, 8) test failed");
+    assert_eq!(utils::path_length_from_key(1, 8), 3, "key (1, 8) test failed");
+    assert_eq!(utils::path_length_from_key(2, 8), 3, "key (2, 8) test failed");
+    assert_eq!(utils::path_length_from_key(3, 8), 3, "key (3, 8) test failed");
+    assert_eq!(utils::path_length_from_key(4, 8), 3, "key (4, 8) test failed");
+    assert_eq!(utils::path_length_from_key(5, 8), 3, "key (5, 8) test failed");
+    assert_eq!(utils::path_length_from_key(6, 8), 3, "key (6, 8) test failed");
+    assert_eq!(utils::path_length_from_key(7, 8), 3, "key (7, 8) test failed");
+}
+
+#[test]
+fn test_bits_len() {
+    assert_eq!(utils::bits_len(0), 0, "bits len 0 test failed");
+    assert_eq!(utils::bits_len(1), 1, "bits len 1 test failed");
+    assert_eq!(utils::bits_len(2), 2, "bits len 2 test failed");
+    assert_eq!(utils::bits_len(3), 2, "bits len 3 test failed");
+    assert_eq!(utils::bits_len(4), 3, "bits len 4 test failed");
+    assert_eq!(utils::bits_len(5), 3, "bits len 5 test failed");
+    assert_eq!(utils::bits_len(6), 3, "bits len 6 test failed");
+    assert_eq!(utils::bits_len(7), 3, "bits len 7 test failed");
+    assert_eq!(utils::bits_len(8), 4, "bits len 8 test failed");
+    assert_eq!(utils::bits_len(16), 5, "bits len 16 test failed");
+}
+
+#[test]
+fn test_get_split_point() {
+    assert_eq!(utils::get_split_point(1), 0, "split point 1 test failed");
+    assert_eq!(utils::get_split_point(2), 1, "split point 2 test failed");
+    assert_eq!(utils::get_split_point(3), 2, "split point 3 test failed");
+    assert_eq!(utils::get_split_point(4), 2, "split point 4 test failed");
+    assert_eq!(utils::get_split_point(5), 4, "split point 5 test failed");
+    assert_eq!(utils::get_split_point(6), 4, "split point 6 test failed");
+    assert_eq!(utils::get_split_point(7), 4, "split point 7 test failed");
+    assert_eq!(utils::get_split_point(8), 4, "split point 8 test failed");
+    assert_eq!(utils::get_split_point(16), 8, "split point 16 test failed");
 }

--- a/src/tree/tests/test_utils.cairo
+++ b/src/tree/tests/test_utils.cairo
@@ -1,0 +1,15 @@
+use blobstream_sn::tree::utils::path_length_from_key;
+
+#[test]
+fn test_path_length_from_keys() {
+    assert_eq!(path_length_from_key(0, 2), 1, "key (0, 2) test failed");
+    assert_eq!(path_length_from_key(1, 2), 1, "key (1, 2) test failed");
+    assert_eq!(path_length_from_key(0, 8), 3, "key (0, 8) test failed");
+    assert_eq!(path_length_from_key(1, 8), 3, "key (1, 8) test failed");
+    assert_eq!(path_length_from_key(2, 8), 3, "key (2, 8) test failed");
+    assert_eq!(path_length_from_key(3, 8), 3, "key (3, 8) test failed");
+    assert_eq!(path_length_from_key(4, 8), 3, "key (4, 8) test failed");
+    assert_eq!(path_length_from_key(5, 8), 3, "key (5, 8) test failed");
+    assert_eq!(path_length_from_key(6, 8), 3, "key (6, 8) test failed");
+    assert_eq!(path_length_from_key(7, 8), 3, "key (7, 8) test failed");
+}

--- a/src/tree/utils.cairo
+++ b/src/tree/utils.cairo
@@ -1,0 +1,59 @@
+use alexandria_math::U256BitShift;
+use blobstream_sn::tree::consts::MAX_HEIGHT;
+
+fn get_starting_bit(num_leaves: u256) -> u256 {
+    let mut starting_bit: u256 = 0;
+    loop {
+        if (U256BitShift::shl(1, starting_bit) < num_leaves) {
+            starting_bit += 1;
+        } else {
+            break;
+        }
+    };
+    MAX_HEIGHT - starting_bit
+}
+
+fn path_length_from_key(key: u256, num_leaves: u256) -> u256 {
+    if (num_leaves <= 1) {
+        return 0;
+    }
+
+    let mut path_length: u256 = MAX_HEIGHT - get_starting_bit(num_leaves);
+
+    let num_leaves_left_sub_tree: u256 = U256BitShift::shl(1, (path_length - 1));
+
+    if (key <= num_leaves_left_sub_tree - 1) {
+        return path_length;
+    } else if (num_leaves_left_sub_tree == 1) {
+        return 1;
+    } else {
+        return 1
+            + path_length_from_key(
+                key - num_leaves_left_sub_tree, num_leaves - num_leaves_left_sub_tree
+            );
+    }
+}
+
+fn bits_len(mut x: u256) -> u256 {
+    let mut count: u256 = 0;
+    loop {
+        if (x == 0) {
+            break;
+        }
+
+        count += 1;
+        x = U256BitShift::shr(x, 1);
+    };
+    count
+}
+
+fn get_split_point(x: u256) -> u256 {
+    assert!(x >= 1, "get split point");
+
+    let bit_len: u256 = bits_len(x);
+    let mut k: u256 = U256BitShift::shl(1, (bit_len - 1));
+    if (x == k) {
+        k = U256BitShift::shr(k, 1);
+    }
+    k
+}

--- a/src/tree/utils.cairo
+++ b/src/tree/utils.cairo
@@ -1,6 +1,7 @@
 use alexandria_math::U256BitShift;
 use blobstream_sn::tree::consts::MAX_HEIGHT;
 
+// Calculate the starting bit of the path to a leaf
 fn get_starting_bit(num_leaves: u256) -> u256 {
     let mut starting_bit: u256 = 0;
     loop {
@@ -10,15 +11,16 @@ fn get_starting_bit(num_leaves: u256) -> u256 {
             break;
         }
     };
-    MAX_HEIGHT - starting_bit
+    starting_bit
 }
 
+// Calculate the length of the path to a leaf with a given key
 fn path_length_from_key(key: u256, num_leaves: u256) -> u256 {
     if (num_leaves <= 1) {
         return 0;
     }
 
-    let mut path_length: u256 = MAX_HEIGHT - get_starting_bit(num_leaves);
+    let mut path_length: u256 = get_starting_bit(num_leaves);
 
     let num_leaves_left_sub_tree: u256 = U256BitShift::shl(1, (path_length - 1));
 
@@ -34,6 +36,7 @@ fn path_length_from_key(key: u256, num_leaves: u256) -> u256 {
     }
 }
 
+// Calculate the minimum number of bits needed to represent `x`
 fn bits_len(mut x: u256) -> u256 {
     let mut count: u256 = 0;
     loop {
@@ -47,6 +50,7 @@ fn bits_len(mut x: u256) -> u256 {
     count
 }
 
+// Calculate the largest power of 2 less than `x`
 fn get_split_point(x: u256) -> u256 {
     assert!(x >= 1, "get split point");
 


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #24 
- [x] follows contribution [guide](../CONTRIBUTING.md)
- [x] code change includes tests
- [ ] breaking change

<!-- PR description below -->

First implemented Celestia's [tree utils](https://github.com/celestiaorg/blobstream-contracts/blob/ddd2b50ad68af541c27f3dffbe4fdfc4f843bb8c/src/lib/tree/Utils.sol), including the corresponding [tests](https://github.com/celestiaorg/blobstream-contracts/blob/ddd2b50ad68af541c27f3dffbe4fdfc4f843bb8c/src/lib/tree/test/Utils.t.sol).

Mainly, implements Celestia's [Binary Merkle tree & Proofs](https://github.com/celestiaorg/blobstream-contracts/blob/ddd2b50ad68af541c27f3dffbe4fdfc4f843bb8c/src/lib/tree/binary/BinaryMerkleTree.sol). Also includes the [same tests](https://github.com/celestiaorg/blobstream-contracts/blob/ddd2b50ad68af541c27f3dffbe4fdfc4f843bb8c/src/lib/tree/binary/test/BinaryMerkleTree.t.sol) from Celestia's implementation.