### PR TITLE
updated cairo to  2.5.3 snforge to 0.17.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.4.4
-starknet-foundry 0.16.0
+scarb 2.5.3
+starknet-foundry 0.17.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -56,9 +56,9 @@ dependencies = [
 [[package]]
 name = "openzeppelin"
 version = "0.8.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.8.1#5c7a022f333dca721fe490c2191a811fa2566a89"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=2815498#2815498b82e7cbc163cb9af9895bd573213d0f94"
 
 [[package]]
 name = "snforge_std"
-version = "0.16.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.16.0#f58e0ab42b6095b7d0cb841ede595aecbc9cb45d"
+version = "0.17.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.17.0#63f7f0b533a3d852e2b60214e0f40b99c9dcbb26"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 test = "snforge test"
 
 [dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.16.0" }
-starknet = "2.4.4"
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.8.1" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.17.0" }
+starknet = ">=2.5.3"
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "2815498" }
 alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git" }
 alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git" }
 
@@ -21,3 +21,6 @@ sierra-replace-ids = true
 
 [tool.fmt]
 sort-module-level-items = true
+
+
+

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -131,7 +131,7 @@ mod BlobstreamX {
             }
 
             // load the tuple root at the given index from storage.
-            let data_root = self.state_data_commitments.read(proof_nonce);
+            let _ = self.state_data_commitments.read(proof_nonce);
 
             // return isProofValid;
             // TODO(#69 + #24): BinaryMerkleTree.verify(root, _proof, abi.encode(_tuple));

--- a/src/tests/test_blobstreamx.cairo
+++ b/src/tests/test_blobstreamx.cairo
@@ -28,10 +28,10 @@ fn blobstreamx_constructor_vals() {
 fn blobstreamx_commit_header_range() {
     let blobstreamx = setup_blobstreamx();
     let state_proof_nonce = blobstreamx.get_state_proof_nonce();
-    let latest_block = blobstreamx.get_latest_block();
+    let _ = blobstreamx.get_latest_block();
     let block_number = get_block_number();
     blobstreamx.commit_header_range(block_number, block_number + 1);
-    let test = blobstreamx.get_state_proof_nonce();
+    let _ = blobstreamx.get_state_proof_nonce();
     assert!(
         blobstreamx.get_state_proof_nonce() == state_proof_nonce + 1, "state proof nonce invalid"
     );
@@ -67,10 +67,10 @@ fn blobstreamx_commit_header_range_target_block_not_in_range_2() {
 fn blobstreamx_commit_next_header() {
     let blobstreamx = setup_blobstreamx();
     let state_proof_nonce = blobstreamx.get_state_proof_nonce();
-    let latest_block = blobstreamx.get_latest_block();
+    let _ = blobstreamx.get_latest_block();
     let block_number = get_block_number();
     blobstreamx.commit_next_header(block_number);
-    let test = blobstreamx.get_state_proof_nonce();
+    let _ = blobstreamx.get_state_proof_nonce();
     assert!(
         blobstreamx.get_state_proof_nonce() == state_proof_nonce + 1, "state proof nonce invalid"
     );

--- a/src/tree/binary/tests/test_merkle_proof.cairo
+++ b/src/tree/binary/tests/test_merkle_proof.cairo
@@ -11,7 +11,7 @@ fn verify_none_test() {
     let num_leaves: u256 = 0;
     let proof: BinaryMerkleProof = BinaryMerkleProof { side_nodes, key, num_leaves };
     let data = BytesTrait::new_empty();
-    let (is_valid, error_code) = merkle_tree::verify(root, @proof, @data);
+    let (is_valid, _) = merkle_tree::verify(root, @proof, @data);
     assert_eq!(is_valid, false, "verify none test failed");
 }
 


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [x] issue #49
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/blobstream-starknet/blob/main/CONTRIBUTING.md)
- [x] code change includes tests
- [x] breaking change

<!-- PR description below -->
Bumped cairo and scarb to 2.5.3 and starknet-foundry to 0.17.0. Several warning are still being generated by dependencies.
