### PR TITLE
dev: Update Scarb to 2.6.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.5.3
-starknet-foundry 0.17.0
+scarb 2.6.3
+starknet-foundry 0.19.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -4,7 +4,7 @@ version = 1
 [[package]]
 name = "alexandria_bytes"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
  "alexandria_data_structures",
  "alexandria_math",
@@ -13,7 +13,7 @@ dependencies = [
 [[package]]
 name = "alexandria_data_structures"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
  "alexandria_encoding",
 ]
@@ -21,8 +21,9 @@ dependencies = [
 [[package]]
 name = "alexandria_encoding"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
+ "alexandria_bytes",
  "alexandria_math",
  "alexandria_numeric",
 ]
@@ -30,7 +31,7 @@ dependencies = [
 [[package]]
 name = "alexandria_math"
 version = "0.2.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
  "alexandria_data_structures",
 ]
@@ -38,7 +39,7 @@ dependencies = [
 [[package]]
 name = "alexandria_numeric"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=8ddf0243#8ddf02430dfe04656ed5bf1b99de7024da1aef41"
+source = "git+https://github.com/keep-starknet-strange/alexandria.git?rev=c1a604e#c1a604eaba40b026c2b477a9b293e40244432e0a"
 dependencies = [
  "alexandria_math",
 ]
@@ -56,18 +57,18 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin"
-version = "0.8.1"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=2815498#2815498b82e7cbc163cb9af9895bd573213d0f94"
+version = "0.10.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?rev=f22438c#f22438cca0e81c807d7c1742e83050ebd0ffcb3b"
 
 [[package]]
 name = "snforge_std"
-version = "0.17.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.17.0#63f7f0b533a3d852e2b60214e0f40b99c9dcbb26"
+version = "0.19.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry?tag=v0.19.0#a3391dce5bdda51c63237032e6cfc64fb7a346d4"
 
 [[package]]
 name = "succinct_sn"
 version = "0.1.0"
-source = "git+https://github.com/keep-starknet-strange/succinct-starknet.git#33bfd3d3d31a136a36fa9432439de31808b9424c"
+source = "git+https://github.com/keep-starknet-strange/succinct-starknet.git?rev=7890c7b#7890c7b5d4ae1fc0ae1237bb85ade3ff131018b5"
 dependencies = [
  "alexandria_bytes",
  "openzeppelin",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -6,12 +6,12 @@ version = "0.1.0"
 test = "snforge test"
 
 [dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.17.0" }
-starknet = ">=2.5.3"
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "2815498" }
-alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "8ddf0243" }
-alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "8ddf0243" }
-succinct_sn = { git = "https://github.com/keep-starknet-strange/succinct-starknet.git" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.19.0" }
+starknet = ">=2.6.3"
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "f22438c" }
+alexandria_bytes = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "c1a604e" }
+alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "c1a604e" }
+succinct_sn = { git = "https://github.com/keep-starknet-strange/succinct-starknet.git", rev = "7890c7b" }
 
 [[target.starknet-contract]]
 casm = true

--- a/src/tests/common.cairo
+++ b/src/tests/common.cairo
@@ -1,8 +1,7 @@
-use openzeppelin::tests::utils::constants::OWNER;
 use openzeppelin::utils::serde::SerializedAppend;
 use snforge_std as snf;
 use snforge_std::{ContractClassTrait, CheatTarget, SpyOn, EventSpy};
-use starknet::ContractAddress;
+use starknet::{ContractAddress, contract_address_const};
 use succinct_sn::fee_vault::succinct_fee_vault;
 use succinct_sn::function_registry::interfaces::{
     IFunctionRegistryDispatcher, IFunctionRegistryDispatcherTrait
@@ -17,30 +16,40 @@ const HEADER_RANGE_DIGEST: u256 = 0xb646edd6dbb2e5482b2449404cf1888b8f4cd6958c79
 const NEXT_HEADER_DIGEST: u256 = 0xfd6c88812a160ff288fe557111815b3433c539c77a3561086cfcdd9482bceb8;
 const TOTAL_SUPPLY: u256 = 0x100000000000000000000000000000001;
 
+fn OWNER() -> ContractAddress {
+    contract_address_const::<'OWNER'>()
+}
+
+fn NEW_OWNER() -> ContractAddress {
+    contract_address_const::<'NEW_OWNER'>()
+}
+
 fn setup_base() -> ContractAddress {
     // deploy the token associated with the fee vault
     let mut calldata = array![];
-    calldata.append_serde('FeeToken');
-    calldata.append_serde('FT');
+    let token_name: ByteArray = "FeeToken";
+    let token_symbol: ByteArray = "FT";
+    calldata.append_serde(token_name);
+    calldata.append_serde(token_symbol);
     calldata.append_serde(TOTAL_SUPPLY);
     calldata.append_serde(OWNER());
-    let token_class = snf::declare('SnakeERC20Mock');
+    let token_class = snf::declare("SnakeERC20Mock");
     let token_address = token_class.deploy(@calldata).unwrap();
 
     // deploy the fee vault 
-    let fee_vault_class = snf::declare('succinct_fee_vault');
+    let fee_vault_class = snf::declare("succinct_fee_vault");
     let fee_calldata = array![token_address.into(), OWNER().into()];
     let fee_vault_address = fee_vault_class.deploy(@fee_calldata).unwrap();
 
     // deploy the succinct gateway
-    let succinct_gateway_class = snf::declare('succinct_gateway');
+    let succinct_gateway_class = snf::declare("succinct_gateway");
     let gateway_addr = succinct_gateway_class
         .deploy(@array![OWNER().into(), fee_vault_address.into()])
         .unwrap();
     let gateway = IFunctionRegistryDispatcher { contract_address: gateway_addr };
 
     // deploy the mock function verifier
-    let func_verifier_class = snf::declare('function_verifier_mock');
+    let func_verifier_class = snf::declare("function_verifier_mock");
     let header_range_verifier = func_verifier_class
         .deploy(@array![HEADER_RANGE_DIGEST.low.into(), HEADER_RANGE_DIGEST.high.into()])
         .unwrap();
@@ -55,7 +64,7 @@ fn setup_base() -> ContractAddress {
         .register_function(OWNER(), next_header_verifier, 'NEXT_HEADER');
 
     // deploy blobstreamx
-    let blobstreamx_class = snf::declare('blobstreamx');
+    let blobstreamx_class = snf::declare("blobstreamx");
     let calldata = array![
         gateway_addr.into(),
         OWNER().into(),
@@ -84,15 +93,15 @@ fn setup_succinct_gateway() -> ContractAddress {
     calldata.append_serde('FT');
     calldata.append_serde(TOTAL_SUPPLY);
     calldata.append_serde(OWNER());
-    let token_class = snf::declare('SnakeERC20Mock');
+    let token_class = snf::declare("SnakeERC20Mock");
     let token_address = token_class.deploy(@calldata).unwrap();
 
     // deploy the fee vault 
-    let fee_vault_class = snf::declare('succinct_fee_vault');
+    let fee_vault_class = snf::declare("succinct_fee_vault");
     let fee_calldata = array![token_address.into(), OWNER().into()];
     let fee_vault_address = fee_vault_class.deploy(@fee_calldata).unwrap();
 
-    let succinct_gateway_class = snf::declare('succinct_gateway');
+    let succinct_gateway_class = snf::declare("succinct_gateway");
     let calldata = array![OWNER().into(), fee_vault_address.into()];
     succinct_gateway_class.deploy(@calldata).unwrap()
 }

--- a/src/tests/test_blobstreamx.cairo
+++ b/src/tests/test_blobstreamx.cairo
@@ -8,6 +8,7 @@ use blobstream_sn::tests::common::{
     setup_base, setup_spied, setup_succinct_gateway, TEST_START_BLOCK, TEST_END_BLOCK, TEST_HEADER,
     OWNER
 };
+use blobstream_sn::tree::binary::merkle_proof::BinaryMerkleProof;
 use snforge_std as snf;
 use snforge_std::{CheatTarget, EventSpy, EventAssertions};
 use starknet::secp256_trait::Signature;

--- a/src/tests/test_blobstreamx.cairo
+++ b/src/tests/test_blobstreamx.cairo
@@ -6,8 +6,8 @@ use blobstream_sn::interfaces::{
 };
 use blobstream_sn::tests::common::{
     setup_base, setup_spied, setup_succinct_gateway, TEST_START_BLOCK, TEST_END_BLOCK, TEST_HEADER,
+    OWNER
 };
-use openzeppelin::tests::utils::constants::OWNER;
 use snforge_std as snf;
 use snforge_std::{CheatTarget, EventSpy, EventAssertions};
 use starknet::secp256_trait::Signature;

--- a/src/tests/test_ownable.cairo
+++ b/src/tests/test_ownable.cairo
@@ -1,7 +1,6 @@
-use blobstream_sn::tests::common::{setup_base, setup_spied};
+use blobstream_sn::tests::common::{setup_base, setup_spied, OWNER, NEW_OWNER};
 use openzeppelin::access::ownable::OwnableComponent;
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use openzeppelin::tests::utils::constants::{OWNER, NEW_OWNER};
 use snforge_std as snf;
 use snforge_std::cheatcodes::events::EventAssertions;
 use snforge_std::{CheatTarget, EventSpy};

--- a/src/tests/test_upgradeable.cairo
+++ b/src/tests/test_upgradeable.cairo
@@ -1,8 +1,7 @@
 use blobstream_sn::mocks::upgradeable::{
     IMockUpgradeableDispatcher, IMockUpgradeableDispatcherTrait
 };
-use blobstream_sn::tests::common::{setup_base, setup_spied};
-use openzeppelin::tests::utils::constants::OWNER;
+use blobstream_sn::tests::common::{setup_base, setup_spied, OWNER};
 use openzeppelin::upgrades::interface::{
     IUpgradeable, IUpgradeableDispatcher, IUpgradeableDispatcherTrait
 };
@@ -25,7 +24,7 @@ fn setup_upgradeable_spied() -> (IUpgradeableDispatcher, EventSpy) {
 #[test]
 fn blobstreamx_upgrade() {
     let (upgradeable, mut spy) = setup_upgradeable_spied();
-    let v2_class = snf::declare('mock_upgradeable');
+    let v2_class = snf::declare("mock_upgradeable");
 
     snf::start_prank(CheatTarget::One(upgradeable.contract_address), OWNER());
     upgradeable.upgrade(v2_class.class_hash);
@@ -52,6 +51,6 @@ fn blobstreamx_upgrade() {
 fn blobstreamx_upgrade_not_owner() {
     let upgradeable = setup_upgradeable();
 
-    let v2_class = snf::declare('mock_upgradeable');
+    let v2_class = snf::declare("mock_upgradeable");
     upgradeable.upgrade(v2_class.class_hash);
 }


### PR DESCRIPTION
<!-- enter the gh issue after hash -->

- [ ] issue #
- [x] follows contribution [guide](https://github.com/keep-starknet-strange/blobstream-starknet/blob/main/CONTRIBUTING.md)
- [ ] code change includes tests
- [x] breaking change

<!-- PR description below -->
Update dependencies and self to `scarb` 2.6.3 and `snforge` 0.19.0

This is needed to allow us to use the latest versions of `openzeppelin` and `Alexandria`, including the latest `sol_abi` in `Alexandria` required for #69 .
NOTE: This PR depends on a commit in this PR on `succinct-starknet` : https://github.com/keep-starknet-strange/succinct-starknet/pull/10